### PR TITLE
DST-359: update email request code review comments

### DIFF
--- a/django_app/feedback/forms.py
+++ b/django_app/feedback/forms.py
@@ -53,6 +53,5 @@ class FeedbackForm(BaseModelForm):
                 max_characters=1200,
                 aria_describedby="how_we_could_improve_the_service-label",
             ),
-            # todo - @Morgan - update your other code to use this new HTMLTemplate class
             HTMLTemplate("feedback/feedback_disclaimer.html"),
         )

--- a/django_app/report_a_suspected_breach/forms.py
+++ b/django_app/report_a_suspected_breach/forms.py
@@ -8,7 +8,6 @@ from core.utils import get_mime_type
 from crispy_forms_gds.choices import Choice
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import (
-    HTML,
     ConditionalQuestion,
     ConditionalRadios,
     Field,
@@ -20,10 +19,10 @@ from crispy_forms_gds.layout import (
 )
 from django import forms
 from django.conf import settings
-from django.template.loader import render_to_string
 from django.urls import reverse_lazy
 from django.utils.timezone import now
 from django_chunk_upload_handlers.clam_av import VirusFoundInFileException
+from feedback.crispy_fields import HTMLTemplate
 from utils.companies_house import (
     get_details_from_companies_house,
     get_formatted_address,
@@ -121,11 +120,9 @@ class EmailVerifyForm(BaseForm):
         request_verify_code = reverse_lazy("report_a_suspected_breach:request_verify_code")
         self.helper["email_verification_code"].wrap(
             Field,
-            HTML(
-                render_to_string(
-                    "report_a_suspected_breach/form_steps/partials/not_received_code_help_text.html",
-                    {"request_verify_code": request_verify_code},
-                )
+            HTMLTemplate(
+                "report_a_suspected_breach/form_steps/partials/not_received_code_help_text.html",
+                {"request_verify_code": request_verify_code},
             ),
         )
 

--- a/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
+++ b/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
@@ -26,3 +26,11 @@
 .js-disabled .govuk-radios__conditional--hidden {
     display: block;
 }
+
+.wide-div {
+    width: 90vw;
+}
+
+.display-inline {
+    display: inline-block;
+}

--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/request_verify_code.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/request_verify_code.html
@@ -17,8 +17,8 @@
                 Still having issues?
             </span>
         </summary>
-        <div class="govuk-details__text">
-            If you're still having problems, contact <a class="govuk-link" href="mailto:DBT-OTSI@businessandtrade.gov.uk">DBT-OTSI@businessandtrade.gov.uk</a>
+        <div class="govuk-details__text wide-div">
+            If you're still having problems, contact <a class="govuk-link display-inline" href="mailto:DBT-OTSI@businessandtrade.gov.uk">DBT-OTSI@businessandtrade.gov.uk</a>
         </div>
     </details>
 


### PR DESCRIPTION
<img width="803" alt="image" src="https://github.com/uktrade/report-a-breach/assets/65167892/668a8ca9-f812-4cdc-bd73-23269c2acf70">

the contact details in the text expander is now on a single line as per Peter's comment. https://uktrade.atlassian.net/browse/DST-359. 