### PR TITLE
show the uk as location of enduser or supplier in summary

### DIFF
--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/summary.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/summary.html
@@ -196,7 +196,11 @@
                 </dt>
                 <dd class="govuk-summary-list__value">
                     {% get_country form_data.about_the_supplier.country as country %}
-                    {{ country.name }}
+                    {% if country.name == "United Kingdom" %}
+                        The UK
+                    {% else %}
+                        {{ country.name }}
+                    {% endif %}
                 </dd>
                 <dd class="govuk-summary-list__actions">
                     <a class="govuk-link"
@@ -231,7 +235,11 @@
                     </dt>
                     <dd class="govuk-summary-list__value">
                         {% get_country value.cleaned_data.country as country %}
-                        {{ country.name }}
+                        {% if country.name == "United Kingdom" %}
+                            The UK
+                        {% else %}
+                            {{ country.name }}
+                        {% endif %}
                     </dd>
                     {% if is_made_available_journey %}
                         <dd class="govuk-summary-list__actions">

--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/partials/summary_report.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/partials/summary_report.html
@@ -119,7 +119,11 @@
                     Location of supplier
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    {{ supplier.country.name }}
+                    {% if supplier.country.name == "United Kingdom" %}
+                        The UK
+                    {% else %}
+                        {{ supplier.country.name }}
+                    {% endif %}
                 </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -152,7 +156,11 @@
                         Location of end-user {{ forloop.counter }}
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        {{ end_user.country.name }}
+                        {% if end_user.country.name == "United Kingdom" %}
+                            The UK
+                        {% else %}
+                            {{ end_user.country.name }}
+                        {% endif %}
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">


### PR DESCRIPTION
<img width="528" alt="image" src="https://github.com/uktrade/report-a-breach/assets/65167892/7936aacb-f0fe-4ab2-b5f5-93412534e751">

Updating to display "The UK" in the summary pages for location of supplier/end user if country is United Kingdom 