### PR TITLE
DST-394/confirmation page download report fixes

### DIFF
--- a/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
+++ b/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
@@ -26,6 +26,10 @@
 
 .print-only {
     display: none;
+    .govuk-heading-m {
+        margin-top: 45px;
+
+    }
 }
 
 @media print {

--- a/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
+++ b/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
@@ -23,18 +23,26 @@
     display: inline-block;
 }
 
+@page
+{
+    size: auto;   /* auto is the initial value */
+    /* this affects the margin in the printer settings */
+    margin: 25mm 25mm 25mm 25mm;
+}
 
 .print-only {
     display: none;
-    .govuk-heading-m {
-        margin-top: 45px;
-
-    }
 }
 
 @media print {
     .print-only {
         display: inherit;
+    }
+    .govuk-grid-column-two-thirds {
+        width: 100%;
+    }
+    .govuk-summary-list__key {
+        width: 50%;
     }
 }
 

--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/partials/summary_report.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/partials/summary_report.html
@@ -16,16 +16,12 @@
         </div>
 
         <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                Business reporter works for
-            </dt>
             {% if breach.reporter_name_of_business_you_work_for %}
+                <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+                    Business reporter works for
+                </dt>
                 <dd class="govuk-summary-list__value">
                     {{ breach.reporter_name_of_business_you_work_for }}
-                </dd>
-            {% else %}
-                <dd class="govuk-summary-list__value">
-                    {{ breacher.name }}
                 </dd>
             {% endif %}
         </div>


### PR DESCRIPTION
- [x] Add more space between print headers/footers and RAB content
- [x] Printed content should be full width not 2/3rds
- [x] Remove reporter business if not specified 
<img width="807" alt="image" src="https://github.com/uktrade/report-a-breach/assets/65167892/a6cdcdae-d2b7-4e68-9aa3-1172ce47bb81">
<img width="798" alt="image" src="https://github.com/uktrade/report-a-breach/assets/65167892/0ba158ce-a260-4cf5-a77c-4bd96411fe80">

FYI, I sent the images of the report to Peter and he's happy with the spacing/width of text. 

