### PR TITLE
Peter comments on DST-441 - Which sanctions regime page

### DIFF
--- a/django_app/report_a_suspected_breach/forms.py
+++ b/django_app/report_a_suspected_breach/forms.py
@@ -457,10 +457,9 @@ class WhichSanctionsRegimeForm(BaseForm):
     def clean(self):
         cleaned_data = super().clean()
         if which_sanctions_regime := cleaned_data.get("which_sanctions_regime"):
-            if "Unknown Regime" in which_sanctions_regime and (
-                (len(which_sanctions_regime) == 2 and "Other Regime" not in cleaned_data["which_sanctions_regime"])
-                or len(which_sanctions_regime) >= 3
-            ):
+            if ("Unknown Regime" in which_sanctions_regime or "Other Regime" in which_sanctions_regime) and len(
+                which_sanctions_regime
+            ) >= 2:
                 # the user has selected "I do not know" and other regimes, this is an issue.
                 # note that the user can select both "I do not know" and "Other Regime"
                 self.add_error(

--- a/django_app/report_a_suspected_breach/static/report_a_suspected_breach/javascript/which_sanctions_regime.js
+++ b/django_app/report_a_suspected_breach/static/report_a_suspected_breach/javascript/which_sanctions_regime.js
@@ -1,15 +1,16 @@
 document.addEventListener("DOMContentLoaded", function (event) {
-    $('input[name$="which_sanctions_regime"][value="Unknown Regime"]').on('change', function () {
+    $(document).on('change', 'input[value="Unknown Regime"], input[value="Other Regime"]', function(){
         if ($(this).is(':checked')) {
-            // clear the other regime inputs
-            $('.govuk-checkboxes__divider').prevAll().find('input[name$="which_sanctions_regime"]').prop('checked', false);
+            // clear the other inputs
+            $('input[name$="which_sanctions_regime"]').not($(this)).prop('checked', false);
         }
-    });
+    })
 
     $('.govuk-checkboxes__divider').prevAll().find('input[name$="which_sanctions_regime"]').on('change', function () {
         if ($(this).is(':checked')) {
             // clear the unknown regime input
             $('input[name$="which_sanctions_regime"][value="Unknown Regime"]').prop('checked', false);
+            $('input[name$="which_sanctions_regime"][value="Other Regime"]').prop('checked', false);
         }
     });
 

--- a/tests/test_unit/test_report_a_suspected_breach/test_forms.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_forms.py
@@ -356,13 +356,16 @@ class TestWhichSanctionsRegimeForm:
         assert flat_choices[-1] == "Other Regime"
         assert flat_choices[-2] == "Unknown Regime"
 
-    def test_other_regime_selected_non_error(self):
-        form = forms.WhichSanctionsRegimeForm(data={"which_sanctions_regime": ["Other Regime", "Unknown Regime"]})
-        assert form.is_valid()
+    def test_assert_unknown_regime_selected_error(self):
+        SanctionsRegimeFactory.create(full_name="test regime")
+        form = forms.WhichSanctionsRegimeForm(data={"which_sanctions_regime": ["Unknown Regime", "test regime"]})
+        assert not form.is_valid()
+        assert "which_sanctions_regime" in form.errors
+        assert form.errors.as_data()["which_sanctions_regime"][0].code == "invalid"
 
     def test_assert_other_regime_selected_error(self):
         SanctionsRegimeFactory.create(full_name="test regime")
-        form = forms.WhichSanctionsRegimeForm(data={"which_sanctions_regime": ["Unknown Regime", "test regime"]})
+        form = forms.WhichSanctionsRegimeForm(data={"which_sanctions_regime": ["Other Regime", "test regime"]})
         assert not form.is_valid()
         assert "which_sanctions_regime" in form.errors
         assert form.errors.as_data()["which_sanctions_regime"][0].code == "invalid"


### PR DESCRIPTION
 when click ‘I do not know’ you can still check ‘Other regime’. I think selecting Other regime should cancel out the I do not know, and vice versa