### PR TITLE
DST-381: Change links for end user

### DIFF
--- a/django_app/report_a_suspected_breach/session.py
+++ b/django_app/report_a_suspected_breach/session.py
@@ -11,6 +11,29 @@ class SessionStorage(WizardSessionStorage):
                     return end_user_dict["dirty_data"]
             else:
                 return None
+        if step == "where_were_the_goods_supplied_to":
+            if end_user_uuid := self.request.resolver_match.kwargs.get("end_user_uuid", None):
+                step_data = super().get_step_data(step)
+                if end_user_dict := self.request.session.get("end_users", {}).get(end_user_uuid, None):
+                    country = end_user_dict["cleaned_data"]["country"]
+                    if country == "GB":
+                        step_data["where_were_the_goods_supplied_to-where_were_the_goods_supplied_to"] = "in_the_uk"
+                    else:
+                        step_data["where_were_the_goods_supplied_to-where_were_the_goods_supplied_to"] = "outside_the_uk"
+                return step_data
+
+        if step == "where_were_the_goods_made_available_to":
+            if end_user_uuid := self.request.resolver_match.kwargs.get("end_user_uuid", None):
+                step_data = super().get_step_data(step)
+                if end_user_dict := self.request.session.get("end_users", {}).get(end_user_uuid, None):
+                    country = end_user_dict["cleaned_data"]["country"]
+                    if country == "GB":
+                        step_data["where_were_the_goods_made_available_to-where_were_the_goods_made_available_to"] = "in_the_uk"
+                    else:
+                        step_data["where_were_the_goods_made_available_to-where_were_the_goods_made_available_to"] = (
+                            "outside_the_uk"
+                        )
+                return step_data
 
         if step == "end_user_added":
             # we don't want to remember people's choices for this step, if they want to add a new end user will change

--- a/tests/test_unit/test_report_a_suspected_breach/test_views/test_wizard_view.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_views/test_wizard_view.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.http import HttpResponseRedirect
 from django.test import RequestFactory
+from django.urls import reverse
 from report_a_suspected_breach.choices import TypeOfRelationshipChoices
 from report_a_suspected_breach.models import (
     Breach,
@@ -113,3 +114,26 @@ class TestReportABreachWizardView:
         person_or_company_details = PersonOrCompany.objects.all()
         assert len(person_or_company_details) == 1
         assert person_or_company_details[0].type_of_relationship == relationship
+
+    def test_where_were_the_goods_supplied_to_url(self, rasb_client):
+        request = RequestFactory().get("/")
+        request.session = rasb_client.session
+        request.session["end_users"] = data.end_users
+        end_user_id = "end_user1"
+        request.session.save()
+
+        response = rasb_client.get(
+            reverse("report_a_suspected_breach:where_were_the_goods_supplied_to", args={"end_user_uuid": end_user_id}),
+        )
+        assert response.status_code == 200
+
+    def test_where_were_the_goods_made_available_to_url(self, rasb_client):
+        request = RequestFactory().get("/")
+        request.session = rasb_client.session
+        request.session["end_users"] = data.end_users
+        end_user_id = "end_user3"
+
+        response = rasb_client.get(
+            reverse("report_a_suspected_breach:where_were_the_goods_made_available_to", args={"end_user_uuid": end_user_id}),
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
- [x] When the location of an end user is changed it selects the correct previous location on the `supplied_to` or `made_available_to` form. 