### PR TITLE
DST-438: Remove idk option if select add another end user

### DIFF
--- a/django_app/report_a_suspected_breach/views.py
+++ b/django_app/report_a_suspected_breach/views.py
@@ -660,9 +660,11 @@ class ZeroEndUsersView(FormView):
         add_end_user = self.form.cleaned_data["do_you_want_to_add_an_end_user"]
         if add_end_user:
             if self.request.session.get("made_available_journey"):
-                return reverse_lazy("report_a_suspected_breach:step", kwargs={"step": "where_were_the_goods_made_available_to"})
+                return f"{get_wizard_step_url('where_were_the_goods_made_available_to')}?add_another_end_user=yes"
+
             else:
-                return reverse_lazy("report_a_suspected_breach:step", kwargs={"step": "where_were_the_goods_supplied_to"})
+                return f"{get_wizard_step_url('where_were_the_goods_made_supplied_to')}?add_another_end_user=yes"
+
         else:
             return reverse_lazy(
                 "report_a_suspected_breach:step", kwargs={"step": "were_there_other_addresses_in_the_supply_chain"}

--- a/django_app/report_a_suspected_breach/views.py
+++ b/django_app/report_a_suspected_breach/views.py
@@ -663,7 +663,7 @@ class ZeroEndUsersView(FormView):
                 return f"{get_wizard_step_url('where_were_the_goods_made_available_to')}?add_another_end_user=yes"
 
             else:
-                return f"{get_wizard_step_url('where_were_the_goods_made_supplied_to')}?add_another_end_user=yes"
+                return f"{get_wizard_step_url('where_were_the_goods_supplied_to')}?add_another_end_user=yes"
 
         else:
             return reverse_lazy(

--- a/tests/test_unit/test_report_a_suspected_breach/test_views/test_zero_enduser_views.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_views/test_zero_enduser_views.py
@@ -14,7 +14,7 @@ class TestZeroEndUsersView:
         expected_redirect = HttpResponseRedirect(
             status=302,
             content_type="text/html; charset=utf-8",
-            redirect_to="/report_a_suspected_breach/where_were_the_goods_supplied_to/",
+            redirect_to="/report_a_suspected_breach/where_were_the_goods_supplied_to/?add_another_end_user=yes",
         )
 
         assert response.status_code == expected_redirect.status_code
@@ -52,7 +52,7 @@ class TestZeroEndUsersView:
         expected_redirect = HttpResponseRedirect(
             status=302,
             content_type="text/html; charset=utf-8",
-            redirect_to="/report_a_suspected_breach/where_were_the_goods_made_available_to/",
+            redirect_to="/report_a_suspected_breach/where_were_the_goods_made_available_to/?add_another_end_user=yes",
         )
 
         assert response.status_code == expected_redirect.status_code


### PR DESCRIPTION
Removing I don't know option when user selects 'add an end user' from the zero end users page