### PR TITLE
Fixing file upload to work on DBT Platform

### DIFF
--- a/django_app/config/settings/test.py
+++ b/django_app/config/settings/test.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.core.cache.backends.dummy import DummyCache
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
 from django.forms import Form
 from django.http import HttpResponse
 
@@ -15,8 +16,15 @@ BASE_FRONTEND_TESTING_URL = "http://report-a-suspected-breach:8000"
 
 ENVIRONMENT = "test"
 
+
+class TestUploadHandler(TemporaryFileUploadHandler):
+    def new_file(self, *args, **kwargs):
+        super().new_file(*args, **kwargs)
+        self.file.original_name = self.file_name
+
+
 # we don't want to connect to ClamAV in testing, redefine and remove from list
-FILE_UPLOAD_HANDLERS = ("core.custom_upload_handler.CustomFileUploadHandler",)  # Order is important
+FILE_UPLOAD_HANDLERS = ("config.settings.test.TestUploadHandler",)
 
 
 # don't use redis when testing

--- a/django_app/core/custom_upload_handler.py
+++ b/django_app/core/custom_upload_handler.py
@@ -1,46 +1,9 @@
-import uuid
-
-from boto3 import client as boto3_client
-from django.conf import settings
-from django_chunk_upload_handlers.s3 import S3FileUploadHandler, ThreadedS3ChunkUploader
+from django_chunk_upload_handlers.s3 import S3FileUploadHandler
+from storages.backends.s3 import S3File
 
 
 class CustomFileUploadHandler(S3FileUploadHandler):
-
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        super().__init__(*args, **kwargs)
-
-    def new_file(self, *args: object, **kwargs: object) -> None:
-        super().new_file(*args, **kwargs)
-        self.new_file_name = self.file_name
-
-        extra_kwargs = {}
-        if endpoint_url := getattr(settings, "AWS_S3_ENDPOINT_URL", None):
-            extra_kwargs["endpoint_url"] = endpoint_url
-
-        extra_kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
-        extra_kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY
-
-        self.s3_client = boto3_client(
-            "s3",
-            region_name=settings.AWS_REGION,
-            **extra_kwargs,
-        )
-
-        self.parts = []
-        self.part_number = 1
-        self.s3_key = f"chunk_upload_{str(uuid.uuid4())}"
-
-        self.multipart = self.s3_client.create_multipart_upload(
-            Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-            Key=self.s3_key,
-            ContentType=self.content_type,
-        )
-
-        self.upload_id = self.multipart["UploadId"]
-        self.executor = ThreadedS3ChunkUploader(
-            client=self.s3_client,
-            bucket=settings.AWS_STORAGE_BUCKET_NAME,
-            key=self.s3_key,
-            upload_id=self.upload_id,
-        )
+    def file_complete(self, file_size: int) -> S3File:
+        """We override this method so we can define a new file name which is the session key + the original file name"""
+        self.new_file_name = f"{self.request.session.session_key}/{self.file_name}"
+        return super().file_complete(file_size)


### PR DESCRIPTION

- Refactoring file upload handler to reduce length.
- Using the original name of the file to set the cache key as we don't want to display the session key to the end-user