### PR TITLE
DST-466: Fix user journey when they do not know companies house number

### DIFF
--- a/django_app/report_a_suspected_breach/form_step_conditions.py
+++ b/django_app/report_a_suspected_breach/form_step_conditions.py
@@ -75,7 +75,7 @@ def show_business_or_personal_details_page(wizard: View) -> bool:
 
     show_page = (
         where_is_the_address_cleaned_data.get("where_is_the_address")
-        and are_you_reporting_a_business_on_companies_house_cleaned_data.get("do_you_know_the_registered_company_number")
+        and are_you_reporting_a_business_on_companies_house_cleaned_data.get("business_registered_on_companies_house")
         in [
             "no",
             "do_not_know",


### PR DESCRIPTION
The show condition was pointing at the incorrect dictionary key for the forms data. Updating the key has corrected the issue. 