### PR TITLE
DST-762: Fix hide_cookies redirect

### DIFF
--- a/django_app/core/templates/core/base.html
+++ b/django_app/core/templates/core/base.html
@@ -72,7 +72,7 @@
                         </div>
                     {% endif %}
                     {% if "cookies_set" in request.GET %}
-                        <form method="post" action="{% url 'hide_cookies' %}?banner=True">
+                        <form method="post" action="{% url 'hide_cookies' %}?banner=True&redirect_back_to={{ request.path }}">
                             {% csrf_token %}
                             <div class="govuk-cookie-banner" data-nosnippet role="region"
                                  aria-label="Cookies on Report a Suspected Breach of Trade Sanctions">


### PR DESCRIPTION
[Jira](https://uktrade.atlassian.net/browse/DST-762)

When the user is on a page other than task-list, and clicks to hide cookies, they were redirected to "/" which is the task-list. This PR fixes this behaviour by adding the redirect_back_to var into the form submission.