### PR TITLE
DST-632: remove end users from cya page

### DIFF
--- a/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
+++ b/django_app/report_a_suspected_breach/static/report_a_suspected_breach/stylesheets/report_a_suspected_breach.css
@@ -7,7 +7,7 @@
     border: none;
     padding: 0 !important;
     cursor: pointer;
-    color: #003078;
+    color: #1d70b8;
     font-size: 19px;
 }
 

--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/check_your_answers.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/check_your_answers.html
@@ -260,19 +260,6 @@
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                        Location of end-user {{ forloop.counter }}
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        {% get_country value.cleaned_data.country as country %}
-                        {% if country.name == "United Kingdom" %}
-                            The UK
-                        {% else %}
-                            Outside the UK
-                        {% endif %}
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
                         Name and address of end-user {{forloop.counter}}
                     </dt>
                     <dd class="govuk-summary-list__value">

--- a/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/check_your_answers.html
+++ b/django_app/report_a_suspected_breach/templates/report_a_suspected_breach/form_steps/check_your_answers.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load countries %}
 {% block title %}Check your answers{% endblock title %}
-{% block form_content %}
+{% block column_content %}
     <div>
         <h1 class="govuk-heading-l">
             Check your answers
@@ -228,7 +228,35 @@
     </dl>
     {% if form_data.end_users %}
         {% for end_user, value in form_data.end_users.items %}
-            <h3 class="govuk-heading-s">End-user {{ forloop.counter }}</h3>
+            <div class="action-wrapper">
+                <h3 class="govuk-heading-s" style="float:left">End-user {{ forloop.counter }}</h3>
+                <dl class="govuk-summary-card__actions">
+                    <dd class="govuk-summary-list__action govuk-!-font-weight-regular">
+
+                        {% if is_made_available_journey %}
+                            <a class="govuk-link" style="font-size: 19px; text-align:right"
+                               href="{% url 'report_a_suspected_breach:where_were_the_goods_made_available_to_end_user_uuid' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
+                                class="govuk-visually-hidden">end-user {{forloop.counter}} details</span></a>
+                        {% else %}
+                            <a class="govuk-link" style="font-size: 19px; text-align:right"
+                               href="{% url 'report_a_suspected_breach:where_were_the_goods_supplied_to_end_user_uuid' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
+                                class="govuk-visually-hidden">end-user {{forloop.counter}} details</span></a>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__action">
+                        <form id="delete_end_user_form_{{ forloop.counter }}" method="post" enctype='multipart/form-data' novalidate
+                              action="{% url 'report_a_suspected_breach:delete_end_user' %}?end_user_uuid={{ end_user }}&success_url=check_your_answers">
+                            <input type="hidden" name="end_user_uuid" value="{{ end_user }}">
+                            <input type="hidden" name="success_url" value = "check_your_answers">
+                            {% csrf_token %}
+                            <button type="submit" class="govuk-link button-that-looks-like-link" form="delete_end_user_form_{{ forloop.counter }}">
+                                Remove<span
+                                    class="govuk-visually-hidden">end-user {{forloop.counter}} details</span>
+                            </button>
+                        </form>
+                    </dd>
+                </dl>
+            </div>
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
@@ -242,19 +270,6 @@
                             Outside the UK
                         {% endif %}
                     </dd>
-                    {% if is_made_available_journey %}
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% url 'report_a_suspected_breach:where_were_the_goods_made_available_to_end_user_uuid' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
-                                class="govuk-visually-hidden">location of end-user {{forloop.counter}}</span></a>
-                        </dd>
-                    {% else %}
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% url 'report_a_suspected_breach:where_were_the_goods_supplied_to_end_user_uuid' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
-                                class="govuk-visually-hidden">location of end-user {{forloop.counter}}</span></a>
-                        </dd>
-                    {% endif %}
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
@@ -265,14 +280,9 @@
                         <br><br>
                         {% include "report_a_suspected_breach/partials/truncated_text.html" with text=value.cleaned_data.readable_address|linebreaksbr %}
                     </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link"
-                           href="{% url 'report_a_suspected_breach:about_the_end_user' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
-                            class="govuk-visually-hidden">name and address of end-user {{forloop.counter}}</span></a>
-                    </dd>
+
                 </div>
                 {% if value.cleaned_data.website %}
-
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
                             Website
@@ -281,11 +291,6 @@
                             <a class="govuk-link"
                                href="{{ value.cleaned_data.website }}">{{ value.cleaned_data.website }}<span
                                 class="govuk-visually-hidden"></span></a>
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% url 'report_a_suspected_breach:about_the_end_user' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
-                                class="govuk-visually-hidden">website of end-user {{forloop.counter}}</span></a>
                         </dd>
                     </div>
                 {% endif %}
@@ -297,15 +302,19 @@
                         <dd class="govuk-summary-list__value">
                             {% include "report_a_suspected_breach/partials/truncated_text.html" with text=value.cleaned_data.additional_contact_details|linebreaksbr %}
                         </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% url 'report_a_suspected_breach:about_the_end_user' end_user_uuid=end_user %}?redirect_to_url=report_a_suspected_breach:check_your_answers">Change<span
-                                class="govuk-visually-hidden">additional contact information of end-user {{forloop.counter}}</span></a>
-                        </dd>
                     </div>
                 {% endif %}
             </dl>
         {% endfor %}
+    {% else %}
+        <h3 class="govuk-heading-s" style="float:left">End-users</h3>
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+                    No end-users added
+                </dt>
+            </div>
+        </dl>
     {% endif %}
     </dl>
     <dl class="govuk-summary-list">
@@ -377,7 +386,7 @@
     <a class="govuk-button" data-module="govuk-button" href="{% url 'report_a_suspected_breach:declaration' %}">
         Continue
     </a>
-{% endblock form_content %}
+{% endblock column_content %}
 
 
 {% block extra_js %}

--- a/django_app/report_a_suspected_breach/views/views_supply_chain.py
+++ b/django_app/report_a_suspected_breach/views/views_supply_chain.py
@@ -149,14 +149,16 @@ class EndUserAddedView(BaseFormView):
 
 class DeleteEndUserView(BaseFormView):
     def post(self, *args: object, **kwargs: object) -> HttpResponse:
-        redirect_to = redirect(reverse_lazy("report_a_suspected_breach:end_user_added"))
+        success_url = reverse_lazy("report_a_suspected_breach:end_user_added")
         if end_user_uuid := self.request.POST.get("end_user_uuid"):
             end_users = self.request.session.pop("end_users", None)
             end_users.pop(end_user_uuid, None)
             self.request.session["end_users"] = end_users
             if len(end_users) == 0:
-                redirect_to = redirect(reverse_lazy("report_a_suspected_breach:zero_end_users"))
-        return redirect_to
+                success_url = reverse_lazy("report_a_suspected_breach:zero_end_users")
+            if redirect_to := self.request.POST.get("success_url"):
+                success_url = reverse_lazy(f"report_a_suspected_breach:{redirect_to}")
+        return redirect(success_url)
 
 
 class ZeroEndUsersView(BaseFormView):

--- a/tests/test_unit/test_report_a_suspected_breach/test_views/data.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_views/data.py
@@ -35,6 +35,7 @@ cleaned_data = {
         "were_there_other_addresses_in_the_supply_chain": "yes",
         "other_addresses_in_the_supply_chain": "These are some other address details",
     },
+    "which_sanctions_regime": {"which_sanctions_regime": []},
     "tell_us_about_the_suspected_breach": {"tell_us_about_the_suspected_breach": "The breach was about accountancy"},
 }
 

--- a/tests/test_unit/test_report_a_suspected_breach/test_views/test_views_end.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_views/test_views_end.py
@@ -1,29 +1,69 @@
-# TODO: To be updated when the final non wizard task is complete
+from unittest.mock import patch
 
-# from django.http import HttpResponse
-# from django.test import RequestFactory
-# from feedback.forms import FeedbackForm
-# from report_a_suspected_breach.views import CompleteView
-#
-#
-# class TestCompleteView:
-#
-#     def test_get_context_data(self, breach_object, rasb_client):
-#         request_object = RequestFactory().get("/")
-#
-#         request_object.session = rasb_client.session
-#         session = rasb_client.session
-#         session.save()
-#         view = CompleteView()
-#         view.setup(request_object)
-#
-#         response = view.get(request_object)
-#
-#         # Assert returns success redirect
-#         expected_response = HttpResponse(status=200, content_type="text/html; charset=utf-8")
-#         feedback_form = response.context_data["feedback_form"]
-#         assert isinstance(feedback_form, FeedbackForm)
-#         breach = response.context_data["breach"]
-#         assert breach.id == breach_object.id
-#         assert response.status_code == expected_response.status_code
-#         assert response["content-type"] == expected_response["content-type"]
+from django.contrib.sessions.models import Session
+from django.http import HttpResponse
+from django.test import RequestFactory
+from report_a_suspected_breach.models import ReporterEmailVerification
+from report_a_suspected_breach.views.views_end import (
+    CheckYourAnswersView,
+    CompleteView,
+    DeclarationView,
+)
+
+from django_app.report_a_suspected_breach.forms.forms_end import DeclarationForm
+
+from . import data
+
+
+class TestCheckYourAnswersView:
+    @patch("report_a_suspected_breach.views.views_end.get_all_cleaned_data")
+    def test_get_context_data(self, mocked_get_all_cleaned_data, request_object):
+        mocked_get_all_cleaned_data.return_value = data.cleaned_data
+        view = CheckYourAnswersView()
+        view.setup(request_object)
+        context_data = view.get_context_data()
+        assert context_data["form_data"] == data.cleaned_data
+        assert not context_data["is_third_party_relationship"]
+
+
+class TestDeclarationView:
+    @patch("report_a_suspected_breach.models.get_all_cleaned_data")
+    def test_form_valid(self, mocked_get_all_cleaned_data, request_object, rasb_client):
+        mocked_get_all_cleaned_data.return_value = data.cleaned_data
+        request_object.session = rasb_client.session
+        request_session = Session.objects.get(session_key=request_object.session.session_key)
+        reporter_object = ReporterEmailVerification.objects.create(
+            reporter_session=request_session, email_verification_code="012345", verified=True
+        )
+        reporter_object.save()
+        view = DeclarationView()
+        view.setup(request_object)
+        response = view.form_valid(DeclarationForm(data={}))
+        assert response.status_code == 302
+        assert response.url == "/report/submission-complete"
+
+
+class TestCompleteView:
+
+    def test_get_context_data(self, breach_object, rasb_client):
+        request_object = RequestFactory().get("/")
+        breach_object.save()
+        request_object.session = rasb_client.session
+        request_object.session["breach_id"] = breach_object.id
+
+        session = rasb_client.session
+        breach_object.reporter_session = Session.objects.get(session_key=session.session_key)
+        breach_object.save()
+        session["breach_id"] = breach_object.id
+
+        view = CompleteView()
+        view.setup(request_object)
+
+        response = view.get(request_object)
+
+        # Assert returns success redirect
+        expected_response = HttpResponse(status=200, content_type="text/html; charset=utf-8")
+        breach = response.context_data["breach"]
+        assert breach.id == breach_object.id
+        assert response.status_code == expected_response.status_code
+        assert response["content-type"] == expected_response["content-type"]

--- a/tests/test_unit/test_report_a_suspected_breach/test_views/test_views_supply_chain.py
+++ b/tests/test_unit/test_report_a_suspected_breach/test_views/test_views_supply_chain.py
@@ -55,6 +55,19 @@ class TestDeleteEndUserView:
         assert response.url == reverse("report_a_suspected_breach:end_user_added")
         assert response.status_code == 302
 
+    def test_deleted_end_user_and_change_success_url(self, rasb_client):
+        request = RequestFactory().post("/")
+        request.session = rasb_client.session
+        request.session["end_users"] = data.end_users
+        request.session.save()
+        response = rasb_client.post(
+            reverse("report_a_suspected_breach:delete_end_user"),
+            data={"end_user_uuid": "end_user1", "success_url": "check_your_answers"},
+        )
+        assert len(rasb_client.session["end_users"]) == 2
+        assert response.url == reverse("report_a_suspected_breach:check_your_answers")
+        assert response.status_code == 302
+
 
 class TestZeroEndUsersView:
     def test_add_an_end_user_post(self, rasb_client):


### PR DESCRIPTION
If no end users: 

<img width="784" alt="image" src="https://github.com/user-attachments/assets/8dbe6b47-9091-4cac-adb7-113c6733a24f">

1 end user: 
<img width="692" alt="image" src="https://github.com/user-attachments/assets/7c91ee67-a813-4c21-974c-8e4e1deca5c1">

2 end users:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/ca63958d-7054-438d-a082-6dcab28b3371">

Also in this PR but done after taking screenshots: 
Removed location of end user as per figma / content SoT
Updated link colour
Adding tests for views_end
