### PR TITLE
DST-1034 - Adding 'Error: ' to title browser tab text when errors appear

### DIFF
--- a/django_app/core/templates/core/base_form_step.html
+++ b/django_app/core/templates/core/base_form_step.html
@@ -6,6 +6,9 @@
 {% endblock extra_css %}
 
 {% block title %}
+    {%  if form.errors %}
+        Error:
+    {% endif %}
     {% if form.form_h1_header %}
         {{ form.form_h1_header }}
     {% else %}

--- a/tests/test_frontend/test_core/test_base_form_step_title_error_message.py
+++ b/tests/test_frontend/test_core/test_base_form_step_title_error_message.py
@@ -7,9 +7,8 @@ from tests.test_frontend.conftest import PlaywrightTestBase
 
 class TestBaseFormStepTitleErrorMessage(PlaywrightTestBase):
     def test_error_in_title(self):
-        self.page.goto("http://report-a-suspected-breach:8001/report/task-list")
         self.page.get_by_role("link", name="Your details").click()
         # Clicking through without inputting an email address
         self.page.get_by_role("button", name="Continue").click()
 
-        expect(self.page).to_have_title(re.compile("Error: ", re.IGNORECASE))
+        expect(self.page).to_have_title(re.compile("Error: "))

--- a/tests/test_frontend/test_core/test_base_form_step_title_error_message.py
+++ b/tests/test_frontend/test_core/test_base_form_step_title_error_message.py
@@ -1,0 +1,15 @@
+import re
+
+from playwright.sync_api import expect
+
+from tests.test_frontend.conftest import PlaywrightTestBase
+
+
+class TestBaseFormStepTitleErrorMessage(PlaywrightTestBase):
+    def test_error_in_title(self):
+        self.page.goto("http://report-a-suspected-breach:8001/report/task-list")
+        self.page.get_by_role("link", name="Your details").click()
+        # Clicking through without inputting an email address
+        self.page.get_by_role("button", name="Continue").click()
+
+        expect(self.page).to_have_title(re.compile("Error: ", re.IGNORECASE))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/902d83e8-fa99-4639-bbd9-7cb4494daf42)
![image](https://github.com/user-attachments/assets/a1b81fd2-ce00-430d-bea4-404a16e0e1b3)
