### PR TITLE
DST-1024: SynchronousOnly Sentry error

### DIFF
--- a/django_app/healthcheck/checks/__init__.py
+++ b/django_app/healthcheck/checks/__init__.py
@@ -1,2 +1,2 @@
-from .db import db_check  # noqa
+# from .db import db_check  # noqa
 from .s3 import s3_check  # noqa

--- a/django_app/healthcheck/checks/__init__.py
+++ b/django_app/healthcheck/checks/__init__.py
@@ -1,2 +1,2 @@
-# from .db import db_check  # noqa
+from .db import db_check  # noqa
 from .s3 import s3_check  # noqa

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -1,6 +1,8 @@
+from asgiref.sync import sync_to_async
 from django.db import DatabaseError, connection
 
 
+@sync_to_async
 def db_check() -> bool:
     """
     Performs a basic check on the database
@@ -10,3 +12,6 @@ def db_check() -> bool:
         return True
     except DatabaseError:
         return False
+
+
+async_function = sync_to_async(db_check)

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -12,6 +12,3 @@ def db_check() -> bool:
         return True
     except DatabaseError:
         return False
-
-
-async_function = sync_to_async(db_check)

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -1,6 +1,5 @@
 import asyncio
 
-# from asgiref.sync import sync_to_async
 from django.db import DatabaseError, connection
 
 

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -3,7 +3,7 @@ from django.db import DatabaseError, connection
 
 
 @sync_to_async(thread_sensitive=False)
-def db_check() -> bool:
+def testdb_check() -> bool:
     """
     Performs a basic check on the database
     """

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -1,14 +1,20 @@
-from asgiref.sync import sync_to_async
+import asyncio
+
+# from asgiref.sync import sync_to_async
 from django.db import DatabaseError, connection
 
 
-@sync_to_async(thread_sensitive=False)
-def testdb_check() -> bool:
+async def db_check() -> bool:
     """
     Performs a basic check on the database
     """
-    try:
-        connection.ensure_connection()
-        return True
-    except DatabaseError:
-        return False
+    loop = asyncio.get_event_loop()
+
+    def _check():
+        try:
+            connection.ensure_connection()
+            return True
+        except DatabaseError:
+            return False
+
+    return await loop.run_in_executor(None, _check)

--- a/django_app/healthcheck/checks/db.py
+++ b/django_app/healthcheck/checks/db.py
@@ -2,7 +2,7 @@ from asgiref.sync import sync_to_async
 from django.db import DatabaseError, connection
 
 
-@sync_to_async
+@sync_to_async(thread_sensitive=False)
 def db_check() -> bool:
     """
     Performs a basic check on the database

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -13,13 +13,13 @@ class HealthCheckView(View):
     Returns an XML file containing the response time and the results of these checks, used by Pingdom to monitor
     the health of the service."""
 
-    def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+    async def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
         # we want to disable the healthcheck if we're building on DBT Platform
         if isinstance(env, DBTPlatformSettings) and env.in_build_step:
             return HttpResponse(status=200)
 
         start = time.time()
-        is_db_good = db_check()
+        is_db_good = await db_check()
         is_s3_good = s3_check()
         all_good = is_db_good and is_s3_good
 

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -6,6 +6,10 @@ from django.shortcuts import render
 from django.views.generic import View
 from healthcheck.checks import db_check, s3_check
 
+print("......debug.....")
+print(db_check)
+print(type(db_check))
+
 
 class HealthCheckView(View):
     """Checks the status of the Report a Breach service itself, and all other backing services.

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -13,13 +13,14 @@ class HealthCheckView(View):
     Returns an XML file containing the response time and the results of these checks, used by Pingdom to monitor
     the health of the service."""
 
-    def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+    @staticmethod
+    async def get(request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
         # we want to disable the healthcheck if we're building on DBT Platform
         if isinstance(env, DBTPlatformSettings) and env.in_build_step:
             return HttpResponse(status=200)
 
         start = time.time()
-        is_db_good = db_check()
+        is_db_good = await db_check()
         is_s3_good = s3_check()
         all_good = is_db_good and is_s3_good
 

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -13,8 +13,7 @@ class HealthCheckView(View):
     Returns an XML file containing the response time and the results of these checks, used by Pingdom to monitor
     the health of the service."""
 
-    @staticmethod
-    async def get(request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+    async def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
         # we want to disable the healthcheck if we're building on DBT Platform
         if isinstance(env, DBTPlatformSettings) and env.in_build_step:
             return HttpResponse(status=200)

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -27,7 +27,7 @@ class HealthCheckView(View):
             Performs a basic check on the database
             """
             try:
-                await sync_to_async(connection.ensure_connection(), thread_sensitive=False)()
+                await sync_to_async(connection.ensure_connection, thread_sensitive=False)()
                 return True
             except DatabaseError:
                 return False

--- a/django_app/healthcheck/views.py
+++ b/django_app/healthcheck/views.py
@@ -1,12 +1,10 @@
 import time
 
-from asgiref.sync import sync_to_async
 from config.env import DBTPlatformSettings, env
-from django.db import DatabaseError, connection
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.generic import View
-from healthcheck.checks import s3_check
+from healthcheck.checks import db_check, s3_check
 
 
 class HealthCheckView(View):
@@ -15,24 +13,13 @@ class HealthCheckView(View):
     Returns an XML file containing the response time and the results of these checks, used by Pingdom to monitor
     the health of the service."""
 
-    async def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+    def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
         # we want to disable the healthcheck if we're building on DBT Platform
         if isinstance(env, DBTPlatformSettings) and env.in_build_step:
             return HttpResponse(status=200)
 
         start = time.time()
-
-        async def db_check() -> bool:
-            """
-            Performs a basic check on the database
-            """
-            try:
-                await sync_to_async(connection.ensure_connection, thread_sensitive=False)()
-                return True
-            except DatabaseError:
-                return False
-
-        is_db_good = await db_check()
+        is_db_good = db_check()
         is_s3_good = s3_check()
         all_good = is_db_good and is_s3_good
 

--- a/tests/test_unit/test_healthcheck.py
+++ b/tests/test_unit/test_healthcheck.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from django.urls import reverse
@@ -30,9 +30,10 @@ def test_s3_broken_healthcheck(mock_s3_check, rasb_client):
     assert response.status_code == 200
 
 
-@patch("healthcheck.views.db_check", return_value=False)
+@patch("healthcheck.views.db_check", new_callable=AsyncMock, return_value=False)
 def test_db_broken_healthcheck(mock_db_check, rasb_client):
     response = rasb_client.get(reverse("healthcheck:healthcheck_ping"))
     content = get_response_content(response)
+    assert mock_db_check.call_count == 1
     assert "FAIL" in content
     assert response.status_code == 200


### PR DESCRIPTION
Sentry recommends using threads or sync_to_async. Used threads via asyncio and updated the unit test to await the return. Deployed successfully to dev and tested the app.